### PR TITLE
Fix tilde expansion in quick-install.sh

### DIFF
--- a/quick-install.sh
+++ b/quick-install.sh
@@ -186,8 +186,8 @@ install_commands() {
         
         if download_file "$base_url/$cmd" "$temp_dir/$cmd" 2>/dev/null; then
             # Create target directory and copy file
-            mkdir -p "~/.claude/commands/$cmd_dir"
-            cp "$temp_dir/$cmd" "~/.claude/commands/$cmd"
+            mkdir -p ~/.claude/commands/$cmd_dir
+            cp "$temp_dir/$cmd" ~/.claude/commands/$cmd
             ((downloaded++))
         else
             print_warning "Failed to download $cmd"


### PR DESCRIPTION
## Summary
- Removes quotes from tilde expansion in `mkdir` and `cp` commands in `quick-install.sh`
- Fixes issue where quoted tildes prevented proper home directory expansion
- Ensures commands are installed to the correct location in user's home directory

## Test plan
- [x] Run `./quick-install.sh` and verify commands are installed to `~/.claude/commands/` (not literal `~/.claude/commands/`)
- [x] Verify downloaded commands are executable and accessible
- [x] Test on different shell environments to ensure compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)